### PR TITLE
Add special casing transform for certain JSX elements.

### DIFF
--- a/packages/h2x-plugin-jsx/src/index.test.js
+++ b/packages/h2x-plugin-jsx/src/index.test.js
@@ -9,11 +9,45 @@ describe('transformJsx', () => {
         <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
         <title>Dismiss</title>
         <desc>Created with Sketch.</desc>
-        <defs></defs>
+        <defs>
+          <linearGradient id="a" x1="50%" x2="50%" y1="0%" y2="100%">
+            <stop offset="0%" stop-color="#FAD961" />
+            <stop offset="100%" stop-color="#F7955D" />
+          </linearGradient>
+          <filter
+            id="b"
+            width="157.1%"
+            height="180%"
+            x="-28.6%"
+            y="-20%"
+            filterUnits="objectBoundingBox">
+            <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1" />
+            <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation=".5" />
+            <feColorMatrix
+              in="shadowBlurOuter1"
+              values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.2 0"
+            />
+          </filter>
+        </defs>
         <g id="Blocks" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
             <g id="Dismiss" stroke="#063855" stroke-width="2">
                 <path d="M51,37 L37,51" id="Shape"></path>
                 <path d="M51,51 L37,37" id="Shape"></path>
+                <circle
+                  cx="43.5"
+                  cy="42.5"
+                  r="31.5"
+                  fill="url(#a)"
+                  opacity=".1"
+                />
+                <circle
+                  fill="#f00"
+                  cx="43.5"
+                  cy="42.5"
+                  r="21.5"
+                  filter="url(#b)"
+                  opacity="1"
+                />
             </g>
         </g>
     </svg>
@@ -29,11 +63,23 @@ describe('transformJsx', () => {
   <desc>
     Created with Sketch.
   </desc>
-  <defs />
+  <defs>
+    <linearGradient id="a" x1="50%" x2="50%" y1="0%" y2="100%">
+      <stop offset="0%" stopColor="#FAD961" />
+      <stop offset="100%" stopColor="#F7955D" />
+    </linearGradient>
+    <filter id="b" width="157.1%" height="180%" x="-28.6%" y="-20%" filterUnits="objectBoundingBox">
+      <feOffset dy={1} in="SourceAlpha" result="shadowOffsetOuter1" />
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation=".5" />
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.2 0" />
+    </filter>
+  </defs>
   <g id="Blocks" stroke="none" strokeWidth={1} fill="none" fillRule="evenodd" strokeLinecap="square">
     <g id="Dismiss" stroke="#063855" strokeWidth={2}>
       <path d="M51,37 L37,51" id="Shape" />
       <path d="M51,51 L37,37" id="Shape" />
+      <circle cx="43.5" cy="42.5" r="31.5" fill="url(#a)" opacity=".1" />
+      <circle fill="#f00" cx="43.5" cy="42.5" r="21.5" filter="url(#b)" opacity={1} />
     </g>
   </g>
 </svg>`)

--- a/packages/h2x-plugin-jsx/src/visitor.js
+++ b/packages/h2x-plugin-jsx/src/visitor.js
@@ -19,6 +19,104 @@ const ELEMENT_ATTRIBUTE_MAPPING = {
   },
 }
 
+// Reference: https://developer.mozilla.org/en-US/docs/Web/SVG/Element#SVG_elements
+const ELEMENT_TAG_NAME_MAPPING = {
+  a: 'a',
+  altglyph: 'altGlyph',
+  altglyphdef: 'altGlyphDef',
+  altglyphitem: 'altGlyphItem',
+  animate: 'animate',
+  animatecolor: 'animateColor',
+  animatemotion: 'animateMotion',
+  animatetransform: 'animateTransform',
+  audio: 'audio',
+  canvas: 'canvas',
+  circle: 'circle',
+  clippath: 'clipPath',
+  'color-profile': 'colorProfile',
+  cursor: 'cursor',
+  defs: 'defs',
+  desc: 'desc',
+  discard: 'discard',
+  ellipse: 'ellipse',
+  feblend: 'feBlend',
+  fecolormatrix: 'feColorMatrix',
+  fecomponenttransfer: 'feComponentTransfer',
+  fecomposite: 'feComposite',
+  feconvolvematrix: 'feConvolveMatrix',
+  fediffuselighting: 'feDiffuseLighting',
+  fedisplacementmap: 'feDisplacementMap',
+  fedistantlight: 'feDistantLight',
+  fedropshadow: 'feDropShadow',
+  feflood: 'feFlood',
+  fefunca: 'feFuncA',
+  fefuncb: 'feFuncB',
+  fefuncg: 'feFuncG',
+  fefuncr: 'feFuncR',
+  fegaussianblur: 'feGaussianBlur',
+  feimage: 'feImage',
+  femerge: 'feMerge',
+  femergenode: 'feMergeNode',
+  femorphology: 'feMorphology',
+  feoffset: 'feOffset',
+  fepointlight: 'fePointLight',
+  fespecularlighting: 'feSpecularLighting',
+  fespotlight: 'feSpotLight',
+  fetile: 'feTile',
+  feturbulence: 'feTurbulence',
+  filter: 'filter',
+  font: 'font',
+  'font-face': 'fontFace',
+  'font-face-format': 'fontFaceFormat',
+  'font-face-name': 'fontFaceName',
+  'font-face-src': 'fontFaceSrc',
+  'font-face-uri': 'fontFaceUri',
+  foreignobject: 'foreignObject',
+  g: 'g',
+  glyph: 'glyph',
+  glyphref: 'glyphRef',
+  hatch: 'hatch',
+  hatchpath: 'hatchpath',
+  hkern: 'hkern',
+  iframe: 'iframe',
+  image: 'image',
+  line: 'line',
+  lineargradient: 'linearGradient',
+  marker: 'marker',
+  mask: 'mask',
+  mesh: 'mesh',
+  meshgradient: 'meshgradient',
+  meshpatch: 'meshpatch',
+  meshrow: 'meshrow',
+  metadata: 'metadata',
+  'missing-glyph': 'missingGlyph',
+  mpath: 'mpath',
+  path: 'path',
+  pattern: 'pattern',
+  polygon: 'polygon',
+  polyline: 'polyline',
+  radialgradient: 'radialGradient',
+  rect: 'rect',
+  script: 'script',
+  set: 'set',
+  solidcolor: 'solidcolor',
+  stop: 'stop',
+  style: 'style',
+  svg: 'svg',
+  switch: 'switch',
+  symbol: 'symbol',
+  text: 'text',
+  textpath: 'textPath',
+  title: 'title',
+  tref: 'tref',
+  tspan: 'tspan',
+  unknown: 'unknown',
+  use: 'use',
+  video: 'video',
+  view: 'view',
+  vkern: 'vkern'
+};
+
 function isNumeric(input) {
   return (
     input !== undefined &&
@@ -47,6 +145,11 @@ function getAttributeName(attribute, node) {
   return attribute.name
 }
 
+function transformTagName(tagName) {
+  const lowercaseTagName = tagName.toLowerCase();
+  return ELEMENT_TAG_NAME_MAPPING[lowercaseTagName] || lowercaseTagName;
+}
+
 function getAttributeValue(attribute) {
   return attribute.value
 }
@@ -63,7 +166,8 @@ export default {
   HTMLElement: {
     enter(path) {
       const jsxElement = new JSXElement()
-      jsxElement.name = path.node.tagName.toLowerCase()
+
+      jsxElement.name = transformTagName(path.node.tagName)
       jsxElement.attributes = listToArray(path.node.attributes)
       jsxElement.children = listToArray(path.node.childNodes)
       path.replace(jsxElement)


### PR DESCRIPTION
I’m using your (super useful) svgr package and noticed a bug when transforming svgs with camel--cased tags. For example `<linearGradient>` was transformed to `<lineargradient>`, after which it no longer rendered in React. I traced it back to `h2x-plugin-jsx` transforming all HTML elements to lowercase. 

This PR introduces a list of tags which need special casing like [react-magic does here](https://github.com/reactjs/react-magic/blob/master/src/htmltojsx.js). While I’m not a fan of this type of listing I don’t really see another way of doing this at the moment.